### PR TITLE
Pin yen/deep differ override

### DIFF
--- a/Libraries/Utilities/differ/deepDiffer.js
+++ b/Libraries/Utilities/differ/deepDiffer.js
@@ -11,10 +11,17 @@
  */
 'use strict';
 
+var deepDiffer = function(...args): bool {
+  if (global.__DEEP_DIFFER_OVERRIDE && typeof global.__DEEP_DIFFER_OVERRIDE === 'function') {
+    return global.__DEEP_DIFFER_OVERRIDE(deepDifferInternal, ...args);
+  }
+  return deepDifferInternal(...args);
+}
+
 /*
  * @returns {bool} true if different, false if equal
  */
-var deepDiffer = function(one: any, two: any): bool {
+var deepDifferInternal = function(one: any, two: any, ...args): bool {
   if (one === two) {
     // Short circuit on identical object references instead of traversing them.
     return false;
@@ -42,13 +49,13 @@ var deepDiffer = function(one: any, two: any): bool {
       return true;
     }
     for (var ii = 0; ii < len; ii++) {
-      if (deepDiffer(one[ii], two[ii])) {
+      if (deepDiffer(one[ii], two[ii], ...args)) {
         return true;
       }
     }
   } else {
     for (var key in one) {
-      if (deepDiffer(one[key], two[key])) {
+      if (deepDiffer(one[key], two[key], ...args)) {
         return true;
       }
     }

--- a/Libraries/Utilities/differ/deepDiffer.js
+++ b/Libraries/Utilities/differ/deepDiffer.js
@@ -13,15 +13,15 @@
 
 var deepDiffer = function(...args): bool {
   if (global.__DEEP_DIFFER_OVERRIDE && typeof global.__DEEP_DIFFER_OVERRIDE === 'function') {
-    return global.__DEEP_DIFFER_OVERRIDE(deepDifferInternal, ...args);
+    return global.__DEEP_DIFFER_OVERRIDE(_deepDiffer, ...args);
   }
-  return deepDifferInternal(...args);
+  return _deepDiffer(...args);
 }
 
 /*
  * @returns {bool} true if different, false if equal
  */
-var deepDifferInternal = function(one: any, two: any, ...args): bool {
+var _deepDiffer = function(one: any, two: any, ...args): bool {
   if (one === two) {
     // Short circuit on identical object references instead of traversing them.
     return false;


### PR DESCRIPTION
This is the react-native side change that gives us the ability to patch `deepDiffer` client-side by supplying an override.

The code is more of short-term mitigation/debugging in that it allows us to provide immediately relief to the crash in the field and at the same time gives us the ability to debug from the inside. We can clean up the use of `global`, make the cyclic diff change permanent, and perhaps contributing back once we figure out how and why `max call stack` overflows in our app.