### PR TITLE
Pin yen/max stack try catch

### DIFF
--- a/Libraries/Renderer/ReactNativeFiber-dev.js
+++ b/Libraries/Renderer/ReactNativeFiber-dev.js
@@ -3687,7 +3687,7 @@ function defaultDiffer(prevProp, nextProp, context) {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
     if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, Object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeFiber-dev.js
+++ b/Libraries/Renderer/ReactNativeFiber-dev.js
@@ -3682,7 +3682,7 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp) {
+function defaultDiffer(prevProp, nextProp, context = {}) {
     try {
       return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
     } catch (e) {

--- a/Libraries/Renderer/ReactNativeFiber-dev.js
+++ b/Libraries/Renderer/ReactNativeFiber-dev.js
@@ -3683,7 +3683,16 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
 function defaultDiffer(prevProp, nextProp) {
-    return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
+    try {
+      return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
+    } catch (e) {
+      if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+        global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+      }
+    }
+    // we get here if and only if deepDiffer throws, return false so that the
+    // cyclic object doesn't get added to the updatePayload for native component
+    return false;
 }
 
 function resolveObject(idOrObject) {
@@ -3747,8 +3756,8 @@ function diffProperties(updatePayload, prevProps, nextProps, validAttributes) {
             var nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp;
             updatePayload[propKey] = nextValue;
         }
-    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
-        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp));
+    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp, { validAttributes }) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
+        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp, { validAttributes }));
         shouldUpdate && (nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp, 
         (updatePayload || (updatePayload = {}))[propKey] = nextValue);
     } else removedKeys = null, removedKeyCount = 0, updatePayload = diffNestedProperty(updatePayload, prevProp, nextProp, attributeConfig), 

--- a/Libraries/Renderer/ReactNativeFiber-dev.js
+++ b/Libraries/Renderer/ReactNativeFiber-dev.js
@@ -3682,17 +3682,17 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp, context = {}) {
-    try {
-      return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
-    } catch (e) {
-      if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-        global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
-      }
+function defaultDiffer(prevProp, nextProp, context) {
+  try {
+    return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
+  } catch (e) {
+    if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
     }
-    // we get here if and only if deepDiffer throws, return false so that the
-    // cyclic object doesn't get added to the updatePayload for native component
-    return false;
+  }
+  // we get here if and only if deepDiffer throws, return false so that the
+  // cyclic object doesn't get added to the updatePayload for native component
+  return false;
 }
 
 function resolveObject(idOrObject) {

--- a/Libraries/Renderer/ReactNativeFiber-prod.js
+++ b/Libraries/Renderer/ReactNativeFiber-prod.js
@@ -3273,7 +3273,7 @@ function defaultDiffer(prevProp, nextProp, context) {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
     if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, Object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeFiber-prod.js
+++ b/Libraries/Renderer/ReactNativeFiber-prod.js
@@ -3268,12 +3268,12 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp, context = {}) {
+function defaultDiffer(prevProp, nextProp, context) {
   try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
-    if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+    if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeFiber-prod.js
+++ b/Libraries/Renderer/ReactNativeFiber-prod.js
@@ -3268,9 +3268,17 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp) {
-    console.log("Pin-Yen:RN_Fiber_prod");
+function defaultDiffer(prevProp, nextProp, context = {}) {
+  try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
+  } catch (e) {
+    if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+    }
+  }
+  // we get here if and only if deepDiffer throws, return false so that the
+  // cyclic object doesn't get added to the updatePayload for native component
+  return false;
 }
 
 function resolveObject(idOrObject) {

--- a/Libraries/Renderer/ReactNativeFiber-prod.js
+++ b/Libraries/Renderer/ReactNativeFiber-prod.js
@@ -3269,6 +3269,7 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
 function defaultDiffer(prevProp, nextProp) {
+    console.log("Pin-Yen:RN_Fiber_prod");
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
 }
 
@@ -3333,8 +3334,8 @@ function diffProperties(updatePayload, prevProps, nextProps, validAttributes) {
             var nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp;
             updatePayload[propKey] = nextValue;
         }
-    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
-        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp));
+    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp, { validAttributes }) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
+        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp, { validAttributes }));
         shouldUpdate && (nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp, 
         (updatePayload || (updatePayload = {}))[propKey] = nextValue);
     } else removedKeys = null, removedKeyCount = 0, updatePayload = diffNestedProperty(updatePayload, prevProp, nextProp, attributeConfig), 

--- a/Libraries/Renderer/ReactNativeStack-dev.js
+++ b/Libraries/Renderer/ReactNativeStack-dev.js
@@ -2348,7 +2348,7 @@ function defaultDiffer(prevProp, nextProp, context) {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
     if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, Object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeStack-dev.js
+++ b/Libraries/Renderer/ReactNativeStack-dev.js
@@ -2343,12 +2343,12 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp, context = {}) {
+function defaultDiffer(prevProp, nextProp, context) {
   try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
-    if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+    if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeStack-dev.js
+++ b/Libraries/Renderer/ReactNativeStack-dev.js
@@ -2343,8 +2343,17 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp) {
+function defaultDiffer(prevProp, nextProp, context = {}) {
+  try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
+  } catch (e) {
+    if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+    }
+  }
+  // we get here if and only if deepDiffer throws, return false so that the
+  // cyclic object doesn't get added to the updatePayload for native component
+  return false;
 }
 
 function resolveObject(idOrObject) {
@@ -2408,8 +2417,8 @@ function diffProperties(updatePayload, prevProps, nextProps, validAttributes) {
             var nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp;
             updatePayload[propKey] = nextValue;
         }
-    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
-        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp));
+    } else if (prevProp !== nextProp) if ("object" != typeof attributeConfig) defaultDiffer(prevProp, nextProp, { validAttributes }) && ((updatePayload || (updatePayload = {}))[propKey] = nextProp); else if ("function" == typeof attributeConfig.diff || "function" == typeof attributeConfig.process) {
+        var shouldUpdate = void 0 === prevProp || ("function" == typeof attributeConfig.diff ? attributeConfig.diff(prevProp, nextProp) : defaultDiffer(prevProp, nextProp, { validAttributes }));
         shouldUpdate && (nextValue = "function" == typeof attributeConfig.process ? attributeConfig.process(nextProp) : nextProp, 
         (updatePayload || (updatePayload = {}))[propKey] = nextValue);
     } else removedKeys = null, removedKeyCount = 0, updatePayload = diffNestedProperty(updatePayload, prevProp, nextProp, attributeConfig), 
@@ -2514,8 +2523,8 @@ function setNativePropsFiber(componentOrHandle, nativeProps) {
         maybeInstance = findNodeHandle_1(componentOrHandle);
     } catch (error) {}
     if (null != maybeInstance) {
-        var viewConfig = maybeInstance.viewConfig, updatePayload = ReactNativeAttributePayload_1.create(nativeProps, viewConfig.validAttributes);
-        UIManager.updateView(maybeInstance._nativeTag, viewConfig.uiViewClassName, updatePayload);
+      var viewConfig = maybeInstance.viewConfig, updatePayload = ReactNativeAttributePayload_1.create(nativeProps, viewConfig.validAttributes);
+      UIManager.updateView(maybeInstance._nativeTag, viewConfig.uiViewClassName, updatePayload);
     }
 }
 

--- a/Libraries/Renderer/ReactNativeStack-dev.js
+++ b/Libraries/Renderer/ReactNativeStack-dev.js
@@ -2523,8 +2523,8 @@ function setNativePropsFiber(componentOrHandle, nativeProps) {
         maybeInstance = findNodeHandle_1(componentOrHandle);
     } catch (error) {}
     if (null != maybeInstance) {
-      var viewConfig = maybeInstance.viewConfig, updatePayload = ReactNativeAttributePayload_1.create(nativeProps, viewConfig.validAttributes);
-      UIManager.updateView(maybeInstance._nativeTag, viewConfig.uiViewClassName, updatePayload);
+        var viewConfig = maybeInstance.viewConfig, updatePayload = ReactNativeAttributePayload_1.create(nativeProps, viewConfig.validAttributes);
+        UIManager.updateView(maybeInstance._nativeTag, viewConfig.uiViewClassName, updatePayload);
     }
 }
 

--- a/Libraries/Renderer/ReactNativeStack-prod.js
+++ b/Libraries/Renderer/ReactNativeStack-prod.js
@@ -1893,12 +1893,12 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp, context = {}) {
+function defaultDiffer(prevProp, nextProp, context) {
   try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
-    if (global.__DEEP_DIFFER_EXCEPTION_CALLBACK && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, {prevProp, nextProp, ...context});
+    if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the

--- a/Libraries/Renderer/ReactNativeStack-prod.js
+++ b/Libraries/Renderer/ReactNativeStack-prod.js
@@ -1893,7 +1893,7 @@ var objects = {}, uniqueID = 1, emptyObject$3 = {}, ReactNativePropRegistry = fu
     }, ReactNativePropRegistry;
 }(), ReactNativePropRegistry_1 = ReactNativePropRegistry, emptyObject$2 = {}, removedKeys = null, removedKeyCount = 0;
 
-function defaultDiffer(prevProp, nextProp) {
+function defaultDiffer(prevProp, nextProp, context = {}) {
   try {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {

--- a/Libraries/Renderer/ReactNativeStack-prod.js
+++ b/Libraries/Renderer/ReactNativeStack-prod.js
@@ -1898,7 +1898,7 @@ function defaultDiffer(prevProp, nextProp, context) {
     return "object" != typeof nextProp || null === nextProp || deepDiffer(prevProp, nextProp);
   } catch (e) {
     if ('__DEEP_DIFFER_EXCEPTION_CALLBACK' in global && typeof global.__DEEP_DIFFER_EXCEPTION_CALLBACK === "function") {
-      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, object.assign({prevProp, nextProp}, context));
+      global.__DEEP_DIFFER_EXCEPTION_CALLBACK(e, Object.assign({prevProp, nextProp}, context));
     }
   }
   // we get here if and only if deepDiffer throws, return false so that the


### PR DESCRIPTION
A different solution to the cyclic object problem - rather than paying the cost of cycle detection on every diff for everyone, this approach opts to pay the price only in the exception case.

We exclude the cyclic object from the `updatePayload` to the native component by try-catch-ing in `defaultDiffer`. `__DEEP_DIFFER_EXCEPTION_CALLBACK` gives the client (in our case, the app) the ability to debug the overflow from the inside.

TODO: experiment and pull more context for the callback to help pinpoint the offending component with the cyclic object.